### PR TITLE
odim 5785: Validating EventTimestamp while submitting test events

### DIFF
--- a/svc-events/events/submittestevent.go
+++ b/svc-events/events/submittestevent.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
@@ -153,7 +154,13 @@ func validAndGenSubTestReq(reqBody []byte) (*common.Event, string, string, []int
 	if val, ok := req["EventTimestamp"]; ok {
 		switch v := val.(type) {
 		case string:
+			_, err := time.Parse(time.RFC3339, v)
+			if err != nil {
+				return nil, response.PropertyValueTypeError, "error: optional parameter EventTimestamp must be of type string", []interface{}{fmt.Sprintf("%v", v), "EventTimestamp"}
+
+			}
 			testEvent.EventTimestamp = v
+
 		default:
 			return nil, response.PropertyValueTypeError, "error: optional parameter EventTimestamp must be of type string", []interface{}{fmt.Sprintf("%v", v), "EventTimestamp"}
 		}

--- a/svc-events/events/submittestevent.go
+++ b/svc-events/events/submittestevent.go
@@ -156,7 +156,7 @@ func validAndGenSubTestReq(reqBody []byte) (*common.Event, string, string, []int
 		case string:
 			_, err := time.Parse(time.RFC3339, v)
 			if err != nil {
-				return nil, response.PropertyValueTypeError, "error: optional parameter EventTimestamp must be of type string", []interface{}{fmt.Sprintf("%v", v), "EventTimestamp"}
+				return nil, response.PropertyValueTypeError, "error: optional parameter EventTimestamp must be of valid date time format", []interface{}{fmt.Sprintf("%v", v), "EventTimestamp"}
 
 			}
 			testEvent.EventTimestamp = v

--- a/svc-events/events/submittestevent_test.go
+++ b/svc-events/events/submittestevent_test.go
@@ -41,7 +41,7 @@ func TestSubmitTestEvent(t *testing.T) {
 		"EventGroupID":      1,
 		"MessageArgs":       []string{"message"},
 		"Severity":          "OK",
-		"EventTimestamp":    "",
+		"EventTimestamp":    "2022-02-01T16:40:35Z",
 		"Message":           "IndicatorChanged",
 		"MessageId":         "IndicatorChanged",
 		"OriginOfCondition": "/redfish/v1/Systems/6d4a0a66-7efa-578e-83cf-44dc68d2874e.1",


### PR DESCRIPTION
This PR contains changes for validating EventTimestamp as per redfish spec.