### PR TITLE
Odim 6132: ODIM Profiles - Failure on Registry Prefixes

### DIFF
--- a/svc-events/evresponse/events.go
+++ b/svc-events/evresponse/events.go
@@ -70,7 +70,7 @@ type EventServiceResponse struct {
 	DeliveryRetryIntervalSeconds      int                           `json:"DeliveryRetryIntervalSeconds"`
 	EventFormatTypes                  []string                      `json:"EventFormatTypes"`
 	EventTypesForSubscription         []string                      `json:"EventTypesForSubscription"` // Deprecated v1.3
-	RegistryPrefixes                  []string                      `json:"RegistryPrefixes,omitempty"`
+	RegistryPrefixes                  []string                      `json:"RegistryPrefixes"`
 	ResourceTypes                     []string                      `json:"ResourceTypes"`
 	ServerSentEventURI                string                        `json:"ServerSentEventUri,omitempty"`
 	ServiceEnabled                    bool                          `json:"ServiceEnabled,omitempty"`

--- a/svc-events/evresponse/events.go
+++ b/svc-events/evresponse/events.go
@@ -70,7 +70,7 @@ type EventServiceResponse struct {
 	DeliveryRetryIntervalSeconds      int                           `json:"DeliveryRetryIntervalSeconds"`
 	EventFormatTypes                  []string                      `json:"EventFormatTypes"`
 	EventTypesForSubscription         []string                      `json:"EventTypesForSubscription"` // Deprecated v1.3
-	RegistryPrefixes                  []string                      `json:"RegistryPrefixes"`
+	RegistryPrefixes                  []string                      `json:"RegistryPrefixes"` //Removed omitempty as this is mandatory property for OCP
 	ResourceTypes                     []string                      `json:"ResourceTypes"`
 	ServerSentEventURI                string                        `json:"ServerSentEventUri,omitempty"`
 	ServiceEnabled                    bool                          `json:"ServiceEnabled,omitempty"`

--- a/svc-events/rpc/events.go
+++ b/svc-events/rpc/events.go
@@ -155,6 +155,7 @@ func (e *Events) GetEventService(ctx context.Context, req *eventsproto.EventSubR
 			"ResourceAdded",
 			"ResourceRemoved",
 			"Alert"},
+		RegistryPrefixes: []string{},
 		ResourceTypes:    resourceTypes,
 		//		ServerSentEventURI:"/redfish/v1/EventService/SSE",
 		ServiceEnabled: isServiceEnabled,

--- a/svc-events/rpc/events.go
+++ b/svc-events/rpc/events.go
@@ -155,7 +155,6 @@ func (e *Events) GetEventService(ctx context.Context, req *eventsproto.EventSubR
 			"ResourceAdded",
 			"ResourceRemoved",
 			"Alert"},
-		RegistryPrefixes: []string{},
 		ResourceTypes:    resourceTypes,
 		//		ServerSentEventURI:"/redfish/v1/EventService/SSE",
 		ServiceEnabled: isServiceEnabled,


### PR DESCRIPTION
This PR contains fix for RegistryPrefixes under EventServiceRoot.
Removed omitempty as this mandatory parameter for OCP requirement